### PR TITLE
stargate bridge - add oft support

### DIFF
--- a/contracts/bridge/VortexStargateBridge.sol
+++ b/contracts/bridge/VortexStargateBridge.sol
@@ -92,7 +92,8 @@ contract VortexStargateBridge is VortexBridgeBase {
         _setPlatformAllowance(_withdrawToken, address(_stargate), sendParam.amountLD);
 
         // bridge the token to the mainnet vault
-        (, receipt, ) = _stargate.sendToken{ value: valueToSend }(sendParam, messagingFee, msg.sender);
+        // solhint-disable-next-line check-send-result
+        (, receipt) = _stargate.send{ value: valueToSend }(sendParam, messagingFee, msg.sender);
 
         // refund user if excess native token sent
         _refundExcessNativeTokenSent(msg.sender, msg.value, messagingFee.nativeFee);

--- a/contracts/helpers/MockStargate.sol
+++ b/contracts/helpers/MockStargate.sol
@@ -62,6 +62,21 @@ contract MockStargate is Utils {
         return MessagingFee({ nativeFee: NATIVE_TOKEN_FEE, lzTokenFee: 0 });
     }
 
+    /// @notice Send tokens through the Stargate
+    /// @dev Emits OFTSent when the send is successful
+    /// @param _sendParam The SendParam object detailing the transaction
+    /// @param _fee The MessagingFee object describing the fee to pay
+    /// @param _refundAddress The address to refund any LZ fees paid in excess
+    /// @return msgReceipt The receipt proving the message was sent
+    /// @return oftReceipt The receipt proving the OFT swap
+    function send(
+        SendParam calldata _sendParam,
+        MessagingFee calldata _fee,
+        address _refundAddress
+    ) external payable returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt) {
+        (msgReceipt, oftReceipt, ) = sendToken(_sendParam, _fee, _refundAddress);
+    }
+
     /// @dev This function is same as `send` in OFT interface but returns the ticket data if in the bus ride mode,
     /// which allows the caller to ride and drive the bus in the same transaction.
     function sendToken(


### PR DESCRIPTION
* Add OFT support (Stargate Hydra) to stargate bridge by changing main bridge function to `send` instead of `sendToken` (`sendToken` is supported only by pools)
* Backward compatibility is ensured due to Stargate pools supporting `send` function (`send` uses `sendToken` underneath)